### PR TITLE
Add support for numeric underscore normalization option

### DIFF
--- a/lib/python-black.js
+++ b/lib/python-black.js
@@ -24,6 +24,11 @@ export default {
       type: "boolean",
       default: false,
       title: "Skip string normalization"
+    },
+    skipNumericUnderscoreNormalization: {
+      type: "boolean",
+      default: false,
+      title: "Skip numeric underscore normalization"
     }
   },
   subscriptions: null,
@@ -84,6 +89,9 @@ export default {
     const args = ["-q", "-l", atom.config.get("python-black.lineLength")];
     if (atom.config.get("python-black.skipStringNormalization")) {
       args.push("-S");
+    }
+    if (atom.config.get("python-black.skipNumericUnderscoreNormalization")) {
+      args.push("-N");
     }
     return args;
   },


### PR DESCRIPTION
This pull request adds support for enabling and disabling the  `--skip-numeric-underscore-normalization` flag.