### PR TITLE
only send line length arg to black if it's defined

### DIFF
--- a/lib/python-black.js
+++ b/lib/python-black.js
@@ -11,7 +11,8 @@ export default {
     },
     lineLength: {
       type: "integer",
-      default: 88, // default is set to 88 in black.
+      // default is set to 88 in black; don't set a default here because it will override
+      // configuration in pyproject.toml
       minimum: 1,
       title: "Maximum line length"
     },
@@ -86,7 +87,11 @@ export default {
   },
 
   loadArgs() {
-    const args = ["-q", "-l", atom.config.get("python-black.lineLength")];
+    const args = ["-q"];
+    if (typeof atom.config.get("python-black.lineLength") === "number") {
+      args.push("-l");
+      args.push(atom.config.get("python-black.lineLength"));
+    }
     if (atom.config.get("python-black.skipStringNormalization")) {
       args.push("-S");
     }


### PR DESCRIPTION
fixes #11 

Other options from `pyproject.toml` _were_ actually getting picked up -- it's just that the line length was always passed to the black CLI, which overrides any value set in `pyproject.toml`. This PR makes it so that we only pass an argument for line length if the user has configured it.